### PR TITLE
Add support for a configurable time limit for suspicious tickets

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -4,6 +4,9 @@ harvest:
   password: 1234
   ssl: true
   daysback: 7
+  # Set a maximum number of hours per entry. If this limit is exceeded the 
+  # entry is considered potentially faulty.
+  # max_entry_hours: 8
 bugyield:
   email_from: bugyield@mycompany.com
   email_fallback: bugyield@mycompany.com

--- a/lib/BugYield/Command/BugYieldCommand.php
+++ b/lib/BugYield/Command/BugYieldCommand.php
@@ -54,7 +54,26 @@ abstract class BugYieldCommand extends \Symfony\Component\Console\Command\Comman
    */
   protected function getHarvestDaysBack() {
     return intval($this->harvestConfig['daysback']);
-  }     
+  }    
+
+  /**
+   * Max number of hours allowed on a single time entry. If this limit is
+   * exceeded the entry is considered potentially faulty.
+   * 
+   * @return int/float/null The number of hours or NULL if not defined.
+   */
+  protected function getMaxEntryHours() {
+    $maxHours = NULL;
+    if (isset($this->harvestConfig['max_entry_hours'])) {
+      $maxHours = $this->harvestConfig['max_entry_hours'];
+      // Do not allow non-numeric number of hours
+      if (!is_numeric($maxHours)) {
+        $this->debug(sprintf('Number of warnings %s is not a valid integer', $maxHours));
+        $maxHours = NULL;
+      }
+    }
+    return $maxHours;
+  } 
 
   /**
    * Fetch url to the bugtracker

--- a/lib/BugYield/Command/TimeSync.php
+++ b/lib/BugYield/Command/TimeSync.php
@@ -108,15 +108,16 @@ class TimeSync extends BugYieldCommand {
         $worklog->taskName  = $taskName;
         $worklog->notes     = $entry->get('notes');
 
-        // report an error if you have one single ticket entry with more than 8 hours straight. That's very odd.
-        if($hoursPerTicket > 8) {
-
-          $output->writeln(sprintf('WARNING: More than 8 hours registrered on %s: %s (%s hours). Email sent to user.',$worklog->harvestId, $worklog->notes, $worklog->hours));
+        // report an error if you have one single ticket entry with more than 
+        // a configurable number of hours straight. That's very odd.
+        if ($this->getMaxEntryHours() &&
+            $hoursPerTicket > $this->getMaxEntryHours()) {
+          $output->writeln(sprintf('WARNING: More than %s hours registrered on %s: %s (%s hours). Email sent to user.', $this->getMaxEntryHours(), $worklog->harvestId, $worklog->notes, $worklog->hours));
 
           $to = '"' . $this->getUserNameById($entry->get('user-id')) . '" <' . $this->getUserEmailById($entry->get('user-id')) . '>';
           $subject = sprintf('BugYield warning: %s hours registered on %s. Really?', $worklog->hours, $worklog->notes);
           $body = array();
-          $body[] = 'The following Harvest entry seems invalid due to more than 8 registered hours on one task:';
+          $body[] = sprintf('The following Harvest entry seems invalid due to more than %s registered hours on one task:', $this->getMaxEntryHours());
           $body[] = '';
           $body[] = print_r($worklog, TRUE);
           $body[] = 'ACTION: Please review the time entry.';


### PR DESCRIPTION
This allows both for en/disabling the functionality
and adjusting it to other companies time schedule.
