### PR TITLE
Title braces

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,5 @@
 on: push
-name: Build, test, and deploy
+name: Run tests
 jobs:
   spec_tests:
     name: Spec tests

--- a/spec/BugYield/Command/TitleSyncSpec.php
+++ b/spec/BugYield/Command/TitleSyncSpec.php
@@ -278,38 +278,40 @@ EOF;
         }
     }
 
-    function it_should_replace_titles(OutputInterface $output)
+    function it_should_replace_titles()
     {
         $this->injectTitles(
             'ID-1',
-            ['ID-1' => 'The title'],
-            $output
+            ['ID-1' => 'The title']
         )->shouldReturn('ID-1[The title]');
 
         $this->injectTitles(
             'ID-1 ID-2',
-            ['ID-1' => 'The title', 'ID-2' => 'The second title'],
-            $output
+            ['ID-1' => 'The title', 'ID-2' => 'The second title']
         )->shouldReturn('ID-1[The title] ID-2[The second title]');
 
         $this->injectTitles(
             'ID-1[An old title]',
-            ['ID-1' => 'The title'],
-            $output
+            ['ID-1' => 'The title']
         )->shouldReturn('ID-1[The title]');
 
         $this->injectTitles(
             'ID-1',
-            ['ID-1' => 'The [bracketed] title'],
-            $output
-        )->shouldReturn('ID-1[The [bracketed] title]');
+            ['ID-1' => 'The [bracketed] title']
+        )->shouldReturn('ID-1[The \\[bracketed\\] title]');
+
+        // A trailing backslash in the title should be separated from the
+        // closing ] with a space, so it wont look like an escaped ].
+        $this->injectTitles(
+            'ID-1',
+            ['ID-1' => 'The [trailing] title\\']
+        )->shouldReturn('ID-1[The \\[trailing\\] title\\ ]');
 
         $this->injectTitles(
-            'ID-1[The old [bracketed] title]postfix',
-            ['ID-1' => 'The [bracketed] title'],
-            $output
+            'ID-1[The old \\[replaced\\] title\\ ]postfix',
+            ['ID-1' => 'The [replaced] title\\']
         )->shouldReturn(
-            'ID-1[The [bracketed] title] (BugYield removed comments due to [brackets] in the ticket title)'
+            'ID-1[The \\[replaced\\] title\\ ]postfix'
         );
     }
 

--- a/spec/BugYield/Command/TitleSyncSpec.php
+++ b/spec/BugYield/Command/TitleSyncSpec.php
@@ -278,6 +278,41 @@ EOF;
         }
     }
 
+    function it_should_replace_titles(OutputInterface $output)
+    {
+        $this->injectTitles(
+            'ID-1',
+            ['ID-1' => 'The title'],
+            $output
+        )->shouldReturn('ID-1[The title]');
+
+        $this->injectTitles(
+            'ID-1 ID-2',
+            ['ID-1' => 'The title', 'ID-2' => 'The second title'],
+            $output
+        )->shouldReturn('ID-1[The title] ID-2[The second title]');
+
+        $this->injectTitles(
+            'ID-1[An old title]',
+            ['ID-1' => 'The title'],
+            $output
+        )->shouldReturn('ID-1[The title]');
+
+        $this->injectTitles(
+            'ID-1',
+            ['ID-1' => 'The [bracketed] title'],
+            $output
+        )->shouldReturn('ID-1[The [bracketed] title]');
+
+        $this->injectTitles(
+            'ID-1[The old [bracketed] title]postfix',
+            ['ID-1' => 'The [bracketed] title'],
+            $output
+        )->shouldReturn(
+            'ID-1[The [bracketed] title] (BugYield removed comments due to [brackets] in the ticket title)'
+        );
+    }
+
     protected function prophesize($class, $data)
     {
         $project = $this->prophet->prophesize($class);

--- a/src/Command/TitleSync.php
+++ b/src/Command/TitleSync.php
@@ -91,7 +91,6 @@ class TitleSync extends BugYieldCommand
         //Update Harvest entries with bug tracker ticket titles in the format [ticket-id]([ticket-title])
         try {
             foreach ($ticketEntries as $entry) {
-                $update = false;
                 $this->debug(".");
 
                 // check for active timers - if we update the entry, then the
@@ -131,7 +130,7 @@ class TitleSync extends BugYieldCommand
                     $this->debug("\\");
                 }
 
-                $newNote = $this->injectTitles($entry->get('notes'), $titles, $output);
+                $newNote = $this->injectTitles($entry->get('notes'), $titles);
                 if ($newNote) {
                     $entry->set('notes', $newNote);
 
@@ -175,49 +174,35 @@ class TitleSync extends BugYieldCommand
      *
      * @return false|string
      */
-    public function injectTitles(string $note, array $titles, OutputInterface $output)
+    public function injectTitles(string $note, array $titles)
     {
         $newNote = $note;
         foreach ($titles as $ticketId => $title) {
-            preg_match('/' . $ticketId . '(?:\[(.*?)\])?/i', $newNote, $matches);
+            // Escape bracket in title. The replacement is backslash hell, the
+            // first four is to get a single backslash in the replacement. It
+            // needs to doubled twice, once for the string and another time
+            // for the rexeg engine. The \1 simply refers to the first capture
+            // group in the rexex (the parenthesis matching [ or ]).
+            $title = preg_replace('/(\[|\])/', '\\\\\1', $title);
+
+            // If the title ends in a backslash, pad it with a space so the
+            // closing ] doesn't look like an escaped ].
+            $title = preg_replace('/\\\\$/', '\\\\ ', $title);
+
+            // Use a negative lookbehind assertion "(?<!\\\\)" to only match ]
+            // not preceded by a backslash. The backslash is quadrupled again
+            // to get past two levels of escaping.
+            preg_match('/' . $ticketId . '(?:\\[(.*?)(?<!\\\\)\\])?/i', $newNote, $matches);
             if (isset($matches[1])) {
-                // No bugs found here yet, but I suspect that we
-                // should encode the matches array.
                 if ($matches[1] != $title) {
-                    // Entry note includes ticket title it does not
-                    // match current title so update it.
-
-                    // Look for double brackets - in there are the
-                    // original ticket name contains brakcets like
-                    // this, then we have a problem as the regex
-                    // will break: "[Bracket] - Antal af noder
-                    // TEST"
-                    if (
-                        strpos($title, "[") !== false ||
-                        strpos($title, "]") !== false
-                    ) {
-                        // Hmm, brackets detected, initiate
-                        // evasive maneuvre :-)
-                        $output->writeln(sprintf(
-                            'WARNING (bad practice) ticket contains [brackets] in title %s: %s',
-                            $ticketId,
-                            $title
-                        ));
-                        // We have to drop comments (if any) and
-                        // just insert the ticket title, as we
-                        // cannot differentiate what's title and
-                        // whats comment.
-                        $newNote = $ticketId . '[' . $title .
-                            '] (BugYield removed comments due to [brackets] in the ticket title)';
-                    } else {
-                        $newNote = preg_replace(
-                            '/' . $ticketId . '(\[.*?\])/i',
-                            $ticketId . '[' . $title . ']',
-                            $newNote
-                        );
-                    }
-
-                    $update = true;
+                    // Entry note includes ticket title it does not match
+                    // current title so update it. Uses the same regex as
+                    // above without the capture groups.
+                    $newNote = preg_replace(
+                        '/' . $ticketId . '(\\[.*?(?<!\\\\)\\])/i',
+                        $ticketId . '[' . $title . ']',
+                        $newNote
+                    );
                 }
             } else {
                 // Entry note does not include ticket title so add it.

--- a/src/Command/TitleSync.php
+++ b/src/Command/TitleSync.php
@@ -131,7 +131,7 @@ class TitleSync extends BugYieldCommand
                     $this->debug("\\");
                 }
 
-                $newNote = $this->injectTitles($entry->get('notes'), $titles);
+                $newNote = $this->injectTitles($entry->get('notes'), $titles, $output);
                 if ($newNote) {
                     $entry->set('notes', $newNote);
 
@@ -175,7 +175,7 @@ class TitleSync extends BugYieldCommand
      *
      * @return false|string
      */
-    protected function injectTitles(string $note, array $titles)
+    public function injectTitles(string $note, array $titles, OutputInterface $output)
     {
         $newNote = $note;
         foreach ($titles as $ticketId => $title) {


### PR DESCRIPTION
Handle brackets in titles better

Escape them so we can properly match the right brace.

Add tests of title replacement.